### PR TITLE
Using Realm Roles

### DIFF
--- a/AspireKeycloak.ApiService/AspireKeycloak.ApiService.csproj
+++ b/AspireKeycloak.ApiService/AspireKeycloak.ApiService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AspireKeycloak.ApiService/AspireKeycloak.ApiService.csproj
+++ b/AspireKeycloak.ApiService/AspireKeycloak.ApiService.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>b99247c4-0d94-4a66-b043-a2bba0014ccc</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AspireKeycloak.ApiService/RoleClaimsTransformation.cs
+++ b/AspireKeycloak.ApiService/RoleClaimsTransformation.cs
@@ -1,0 +1,17 @@
+using System.Security.Claims;
+using AspireKeycloak.ServiceDefaults;
+using Microsoft.AspNetCore.Authentication;
+
+namespace AspireKeycloak.ApiService;
+
+public class RoleClaimsTransformation : IClaimsTransformation
+{
+    public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        var identity = principal.Identity as ClaimsIdentity;
+        var realmAccessClaim = identity?.FindFirst("realm_access");
+        identity?.AddRealmRoles(realmAccessClaim?.Value);
+
+        return Task.FromResult(principal);
+    }
+}

--- a/AspireKeycloak.AppHost/AspireKeycloak.AppHost.csproj
+++ b/AspireKeycloak.AppHost/AspireKeycloak.AppHost.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>

--- a/AspireKeycloak.ServiceDefaults/AspireKeycloak.ServiceDefaults.csproj
+++ b/AspireKeycloak.ServiceDefaults/AspireKeycloak.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/AspireKeycloak.ServiceDefaults/RealmAccess.cs
+++ b/AspireKeycloak.ServiceDefaults/RealmAccess.cs
@@ -1,0 +1,3 @@
+namespace AspireKeycloak.Web;
+
+public class RealmAccess { public List<string>? Roles { get; set; } } // one user can be assigned multiple roles

--- a/AspireKeycloak.Web/AspireKeycloak.Web.csproj
+++ b/AspireKeycloak.Web/AspireKeycloak.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/AspireKeycloak.Web/AspireKeycloak.Web.csproj
+++ b/AspireKeycloak.Web/AspireKeycloak.Web.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>c9046b03-084f-4b21-8f67-d1be9641e722</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,11 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="8.2.0-preview.1.24428.5" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="8.2.0-preview.1.24428.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,16 +3,16 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="8.2.0-preview.1.24428.5" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="8.2.0-preview.1.24428.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="8.2.0-preview.1.24428.5" />
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="8.2.0-preview.1.24428.5" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="9.0.0-preview.5.24551.3" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="9.0.0-preview.5.24551.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />


### PR DESCRIPTION
This pull adds authorization so that a user must belong to the realm role 'forcaster' in order to see the forcast.

Very contrived scenario - but the point of all this was to explore how hard it would be to actually use keycloak realm roles in the aspire app.

Essentially is took some mapping at the webfront and the API to get it all working.